### PR TITLE
Adds support for having ha_key loaded from secrets file

### DIFF
--- a/appdaemon/rootfs/etc/cont-init.d/30-auto-password.sh
+++ b/appdaemon/rootfs/etc/cont-init.d/30-auto-password.sh
@@ -10,7 +10,8 @@ readonly CONFIG_FILE="/config/appdaemon/appdaemon.yaml"
 declare TMP_FILE
 
 if [[ "$(yq -r '.appdaemon.plugins.HASS.ha_url' ${CONFIG_FILE})" = "http://hassio/homeassistant"
-    && "$(yq -r '.appdaemon.plugins.HASS.ha_key' ${CONFIG_FILE})" != "${HASSIO_TOKEN}" ]];
+    && "$(yq -r '.appdaemon.plugins.HASS.ha_key' ${CONFIG_FILE})" != "${HASSIO_TOKEN}"
+    && "$(yq -r '.appdaemon.plugins.HASS.ha_key' ${CONFIG_FILE})" != "!secret "* ]];
 then
     TMP_FILE=$(mktemp)
 


### PR DESCRIPTION
# Proposed Changes

In case the `ha_key` is fetched from a secrets file, the add-on should not overwrite it.

## Related Issues

Ref #15